### PR TITLE
[Migration] 5Dim Battlefield, Energy, Mining, Transport

### DIFF
--- a/5dim_battlefield/migrations/5dim_battlefield_1.1.0.json
+++ b/5dim_battlefield/migrations/5dim_battlefield_1.1.0.json
@@ -1,4 +1,22 @@
 {
+	"entity": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
+	"item": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
+	"recipe": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
     "technology": [
         ["5d-turrets-big-1", "5d-gun-turret-big-1"],
         ["5d-turrets-big-2", "5d-gun-turret-big-2"],

--- a/5dim_energy/migrations/5dim_energy_1.1.0.json
+++ b/5dim_energy/migrations/5dim_energy_1.1.0.json
@@ -1,0 +1,71 @@
+{
+    "item": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-01"],
+        ["5d-lamp-2", "5d-lamp-02"],
+        ["5d-lamp-3", "5d-lamp-03"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+    "entity": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-02"],
+        ["5d-lamp-2", "5d-lamp-03"],
+        ["5d-lamp-3", "5d-lamp-04"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+	"recipe": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-01"],
+        ["5d-lamp-2", "5d-lamp-02"],
+        ["5d-lamp-3", "5d-lamp-03"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+	"technology": [
+		["boiler-tech", "5d-boiler-1"],
+		["boiler-tech-2", "5d-boiler-2"],
+		["engine-2", "5d-steam-engine-1"],
+		["engine-3", "5d-steam-engine-2"]
+	]
+}

--- a/5dim_mining/migrations/5dim_mining_1.1.0.json
+++ b/5dim_mining/migrations/5dim_mining_1.1.0.json
@@ -1,0 +1,32 @@
+{
+    "item": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
+    ],
+    "entity": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+    ],
+	"recipe": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+    ],
+	"technology":[
+		["offshore-pump-tech", "5d-offshore-pump-1"],
+		["offshore-pump-tech-2", "5d-offshore-pump-2"],
+		["mining", "5d-mining-1"],
+		["mining-2", "5d-mining-2"],
+		["mining-3", "5d-mining-3"],
+		["water-pumpjack", "5d-water-pumpjack-1"]
+	]
+}

--- a/5dim_mining/migrations/5dim_mining_1.1.0.json
+++ b/5dim_mining/migrations/5dim_mining_1.1.0.json
@@ -5,6 +5,8 @@
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
 		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
 		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
     "entity": [
@@ -12,14 +14,22 @@
 		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
-		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
 	"recipe": [
 		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
 		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
-		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
 	"technology":[
 		["offshore-pump-tech", "5d-offshore-pump-1"],

--- a/5dim_mining/prototypes/gen-electric-mining-drill.lua
+++ b/5dim_mining/prototypes/gen-electric-mining-drill.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 200
 
--- Electric furnace 01
+-- Electric Mining Drill 01
 genMiningDrills {
     number = "01",
     subgroup = "mining-speed",
@@ -30,7 +30,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Electric Mining Drill 02
 genMiningDrills {
     number = "02",
     subgroup = "mining-speed",
@@ -65,7 +65,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Electric Mining Drill 03
 genMiningDrills {
     number = "03",
     subgroup = "mining-speed",
@@ -100,7 +100,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Electric Mining Drill 04
 genMiningDrills {
     number = "04",
     subgroup = "mining-speed",
@@ -136,7 +136,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Electric Mining Drill 05
 genMiningDrills {
     number = "05",
     subgroup = "mining-speed",
@@ -172,7 +172,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Electric Mining Drill 06
 genMiningDrills {
     number = "06",
     subgroup = "mining-speed",
@@ -209,7 +209,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Electric Mining Drill 07
 genMiningDrills {
     number = "07",
     subgroup = "mining-speed",
@@ -246,7 +246,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Electric Mining Drill 08
 genMiningDrills {
     number = "08",
     subgroup = "mining-speed",
@@ -284,7 +284,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Electric Mining Drill 09
 genMiningDrills {
     number = "09",
     subgroup = "mining-speed",
@@ -322,7 +322,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Electric Mining Drill 10
 genMiningDrills {
     number = "10",
     subgroup = "mining-speed",

--- a/5dim_mining/prototypes/gen-offshore-pump.lua
+++ b/5dim_mining/prototypes/gen-offshore-pump.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 100
 
--- Electric furnace 01
+-- Offshore Pump 01
 genOffshorePumps {
     number = "01",
     subgroup = "liquid-offshore-pump",
@@ -30,7 +30,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Offshore Pump 02
 genOffshorePumps {
     number = "02",
     subgroup = "liquid-offshore-pump",
@@ -65,7 +65,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Offshore Pump 03
 genOffshorePumps {
     number = "03",
     subgroup = "liquid-offshore-pump",
@@ -100,7 +100,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Offshore Pump 04
 genOffshorePumps {
     number = "04",
     subgroup = "liquid-offshore-pump",
@@ -136,7 +136,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Offshore Pump 05
 genOffshorePumps {
     number = "05",
     subgroup = "liquid-offshore-pump",
@@ -172,7 +172,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Offshore Pump 06
 genOffshorePumps {
     number = "06",
     subgroup = "liquid-offshore-pump",
@@ -209,7 +209,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Offshore Pump 07
 genOffshorePumps {
     number = "07",
     subgroup = "liquid-offshore-pump",
@@ -246,7 +246,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Offshore Pump 08
 genOffshorePumps {
     number = "08",
     subgroup = "liquid-offshore-pump",
@@ -284,7 +284,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Offshore Pump 09
 genOffshorePumps {
     number = "09",
     subgroup = "liquid-offshore-pump",
@@ -323,7 +323,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Offshore Pump 10
 genOffshorePumps {
     number = "10",
     subgroup = "liquid-offshore-pump",

--- a/5dim_mining/prototypes/gen-water-pumpjack.lua
+++ b/5dim_mining/prototypes/gen-water-pumpjack.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 150
 
--- Electric furnace 01
+-- Water pumpjack 01
 genWaterPumpjacks {
     number = "01",
     subgroup = "liquid-water",
@@ -42,7 +42,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Water pumpjack 02
 genWaterPumpjacks {
     number = "02",
     subgroup = "liquid-water",
@@ -77,7 +77,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Water pumpjack 03
 genWaterPumpjacks {
     number = "03",
     subgroup = "liquid-water",
@@ -113,7 +113,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Water pumpjack 04
 genWaterPumpjacks {
     number = "04",
     subgroup = "liquid-water",
@@ -150,7 +150,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Water pumpjack 05
 genWaterPumpjacks {
     number = "05",
     subgroup = "liquid-water",
@@ -187,7 +187,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Water pumpjack 06
 genWaterPumpjacks {
     number = "06",
     subgroup = "liquid-water",
@@ -225,7 +225,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Water pumpjack 07
 genWaterPumpjacks {
     number = "07",
     subgroup = "liquid-water",
@@ -263,7 +263,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Water pumpjack 08
 genWaterPumpjacks {
     number = "08",
     subgroup = "liquid-water",
@@ -302,7 +302,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Water pumpjack 09
 genWaterPumpjacks {
     number = "09",
     subgroup = "liquid-water",
@@ -341,7 +341,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Water pumpjack 10
 genWaterPumpjacks {
     number = "10",
     subgroup = "liquid-water",

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -11,8 +11,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -32,12 +32,13 @@
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk2", "pipe"],
+		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk3", "pipe"],
+		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
-		
+		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]t
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],
@@ -51,8 +52,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -68,13 +69,14 @@
         ["5d-mk5-splitter", "5d-splitter-05"],
         ["5d-mk5-loader", "5d-loader-05"],
 		
-		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk2", "pipe"],
+		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk3", "pipe"],
+		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
     ],
@@ -90,8 +92,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -106,5 +108,8 @@
         ["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
         ["5d-mk5-splitter", "5d-splitter-05"],
         ["5d-mk5-loader", "5d-loader-05"]
-    ]
+    ],
+	"technology": [
+		["", ""]
+	]
 }

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -38,7 +38,7 @@
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]t
+		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -30,15 +30,15 @@
 		
 		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
 		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-mk2-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
+		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],
@@ -70,15 +70,15 @@
         ["5d-mk5-loader", "5d-loader-05"],
 		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
 		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-mk2-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
+		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
     ],
 	"recipe": [
         ["long-handed-inserter", "fast-inserter"],


### PR DESCRIPTION
Partial fix for #24

Migrates a lot of items, entities, recipes and technologies from _Battlefield_, _Energy_ and _Mining_.
Fixes an error in the migration for _Transport_ (Express prefix added to -03)