### PR TITLE
[Migration] Ores 1.1.0

### DIFF
--- a/5dim_battlefield/migrations/5dim_battlefield_1.1.0.json
+++ b/5dim_battlefield/migrations/5dim_battlefield_1.1.0.json
@@ -1,4 +1,22 @@
 {
+	"entity": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
+	"item": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
+	"recipe": [
+		["5d-gun-turret-small", "5d-gun-turret-small-01"],
+		["5d-gun-turret-exp", "5d-gun-turret-exp-01"],
+		["5d-gun-turret-big", "5d-gun-turret-big-01"],
+		["5d-metal-wall", "5d-stone-wall-02"]
+	],
     "technology": [
         ["5d-turrets-big-1", "5d-gun-turret-big-1"],
         ["5d-turrets-big-2", "5d-gun-turret-big-2"],

--- a/5dim_energy/migrations/5dim_energy_1.1.0.json
+++ b/5dim_energy/migrations/5dim_energy_1.1.0.json
@@ -1,0 +1,71 @@
+{
+    "item": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-01"],
+        ["5d-lamp-2", "5d-lamp-02"],
+        ["5d-lamp-3", "5d-lamp-03"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+    "entity": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-02"],
+        ["5d-lamp-2", "5d-lamp-03"],
+        ["5d-lamp-3", "5d-lamp-04"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+	"recipe": [
+        ["5d-solar-panel", "5d-solar-panel-01"],
+        ["5d-solar-panel-2", "5d-solar-panel-02"],
+        ["5d-solar-panel-3", "5d-solar-panel-03"],
+		
+        ["5d-steam-engine", "5d-steam-engine-01"],
+        ["5d-steam-engine-2", "5d-steam-engine-02"],
+        ["5d-steam-engine-3", "5d-steam-engine-03"],
+		
+        ["5d-lamp", "5d-lamp-01"],
+        ["5d-lamp-2", "5d-lamp-02"],
+        ["5d-lamp-3", "5d-lamp-03"],
+		
+        ["5d-boiler", "5d-boiler-01"],
+        ["5d-boiler-2", "5d-boiler-02"],
+        ["5d-boiler-3", "5d-boiler-03"],
+		
+        ["5d-basic-accumulator", "5d-accumulator-01"],
+        ["5d-basic-accumulator-2", "5d-accumulator-02"],
+        ["5d-basic-accumulator-3", "5d-accumulator-03"]
+    ],
+	"technology": [
+		["boiler-tech", "5d-boiler-1"],
+		["boiler-tech-2", "5d-boiler-2"],
+		["engine-2", "5d-steam-engine-1"],
+		["engine-3", "5d-steam-engine-2"]
+	]
+}

--- a/5dim_mining/migrations/5dim_mining_1.1.0.json
+++ b/5dim_mining/migrations/5dim_mining_1.1.0.json
@@ -1,0 +1,32 @@
+{
+    "item": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
+    ],
+    "entity": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+    ],
+	"recipe": [
+		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
+		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
+		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
+		["5d-offshore-pump", "5d-offshore-pump-02"],
+		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+    ],
+	"technology":[
+		["offshore-pump-tech", "5d-offshore-pump-1"],
+		["offshore-pump-tech-2", "5d-offshore-pump-2"],
+		["mining", "5d-mining-1"],
+		["mining-2", "5d-mining-2"],
+		["mining-3", "5d-mining-3"],
+		["water-pumpjack", "5d-water-pumpjack-1"]
+	]
+}

--- a/5dim_mining/migrations/5dim_mining_1.1.0.json
+++ b/5dim_mining/migrations/5dim_mining_1.1.0.json
@@ -5,6 +5,8 @@
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
 		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
 		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
     "entity": [
@@ -12,14 +14,22 @@
 		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
-		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
 	"recipe": [
 		["5d-mining-drill-speed-1", "5d-electric-mining-drill-02"],
 		["5d-mining-drill-speed-2", "5d-electric-mining-drill-03"],
 		["5d-mining-drill-speed-3", "5d-electric-mining-drill-04"],
 		["5d-offshore-pump", "5d-offshore-pump-02"],
-		["5d-offshore-pump-2", "5d-offshore-pump-03"]
+		["5d-offshore-pump-2", "5d-offshore-pump-03"],
+		
+		["5d-pumpjack-2", "5d-pumpjack-02"],
+		["5d-pumpjack-3", "5d-pumpjack-03"],
+		["5d-water-pumpjack", "5d-water-pumpjack-01"]
     ],
 	"technology":[
 		["offshore-pump-tech", "5d-offshore-pump-1"],

--- a/5dim_mining/prototypes/gen-electric-mining-drill.lua
+++ b/5dim_mining/prototypes/gen-electric-mining-drill.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 200
 
--- Electric furnace 01
+-- Electric Mining Drill 01
 genMiningDrills {
     number = "01",
     subgroup = "mining-speed",
@@ -30,7 +30,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Electric Mining Drill 02
 genMiningDrills {
     number = "02",
     subgroup = "mining-speed",
@@ -65,7 +65,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Electric Mining Drill 03
 genMiningDrills {
     number = "03",
     subgroup = "mining-speed",
@@ -100,7 +100,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Electric Mining Drill 04
 genMiningDrills {
     number = "04",
     subgroup = "mining-speed",
@@ -136,7 +136,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Electric Mining Drill 05
 genMiningDrills {
     number = "05",
     subgroup = "mining-speed",
@@ -172,7 +172,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Electric Mining Drill 06
 genMiningDrills {
     number = "06",
     subgroup = "mining-speed",
@@ -209,7 +209,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Electric Mining Drill 07
 genMiningDrills {
     number = "07",
     subgroup = "mining-speed",
@@ -246,7 +246,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Electric Mining Drill 08
 genMiningDrills {
     number = "08",
     subgroup = "mining-speed",
@@ -284,7 +284,7 @@ speed = speed + 0.5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Electric Mining Drill 09
 genMiningDrills {
     number = "09",
     subgroup = "mining-speed",
@@ -322,7 +322,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Electric Mining Drill 10
 genMiningDrills {
     number = "10",
     subgroup = "mining-speed",

--- a/5dim_mining/prototypes/gen-offshore-pump.lua
+++ b/5dim_mining/prototypes/gen-offshore-pump.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 100
 
--- Electric furnace 01
+-- Offshore Pump 01
 genOffshorePumps {
     number = "01",
     subgroup = "liquid-offshore-pump",
@@ -30,7 +30,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Offshore Pump 02
 genOffshorePumps {
     number = "02",
     subgroup = "liquid-offshore-pump",
@@ -65,7 +65,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Offshore Pump 03
 genOffshorePumps {
     number = "03",
     subgroup = "liquid-offshore-pump",
@@ -100,7 +100,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Offshore Pump 04
 genOffshorePumps {
     number = "04",
     subgroup = "liquid-offshore-pump",
@@ -136,7 +136,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Offshore Pump 05
 genOffshorePumps {
     number = "05",
     subgroup = "liquid-offshore-pump",
@@ -172,7 +172,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Offshore Pump 06
 genOffshorePumps {
     number = "06",
     subgroup = "liquid-offshore-pump",
@@ -209,7 +209,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Offshore Pump 07
 genOffshorePumps {
     number = "07",
     subgroup = "liquid-offshore-pump",
@@ -246,7 +246,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Offshore Pump 08
 genOffshorePumps {
     number = "08",
     subgroup = "liquid-offshore-pump",
@@ -284,7 +284,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Offshore Pump 09
 genOffshorePumps {
     number = "09",
     subgroup = "liquid-offshore-pump",
@@ -323,7 +323,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Offshore Pump 10
 genOffshorePumps {
     number = "10",
     subgroup = "liquid-offshore-pump",

--- a/5dim_mining/prototypes/gen-water-pumpjack.lua
+++ b/5dim_mining/prototypes/gen-water-pumpjack.lua
@@ -6,7 +6,7 @@ local energy = 90
 local emisions = 10
 local techCount = 150
 
--- Electric furnace 01
+-- Water pumpjack 01
 genWaterPumpjacks {
     number = "01",
     subgroup = "liquid-water",
@@ -42,7 +42,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 02
+-- Water pumpjack 02
 genWaterPumpjacks {
     number = "02",
     subgroup = "liquid-water",
@@ -77,7 +77,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 03
+-- Water pumpjack 03
 genWaterPumpjacks {
     number = "03",
     subgroup = "liquid-water",
@@ -113,7 +113,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 04
+-- Water pumpjack 04
 genWaterPumpjacks {
     number = "04",
     subgroup = "liquid-water",
@@ -150,7 +150,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 05
+-- Water pumpjack 05
 genWaterPumpjacks {
     number = "05",
     subgroup = "liquid-water",
@@ -187,7 +187,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 06
+-- Water pumpjack 06
 genWaterPumpjacks {
     number = "06",
     subgroup = "liquid-water",
@@ -225,7 +225,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 07
+-- Water pumpjack 07
 genWaterPumpjacks {
     number = "07",
     subgroup = "liquid-water",
@@ -263,7 +263,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 08
+-- Water pumpjack 08
 genWaterPumpjacks {
     number = "08",
     subgroup = "liquid-water",
@@ -302,7 +302,7 @@ speed = speed + 5
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 09
+-- Water pumpjack 09
 genWaterPumpjacks {
     number = "09",
     subgroup = "liquid-water",
@@ -341,7 +341,7 @@ modules = modules + 1
 energy = energy + 45
 emisions = emisions + 5
 
--- Electric furnace 10
+-- Water pumpjack 10
 genWaterPumpjacks {
     number = "10",
     subgroup = "liquid-water",

--- a/5dim_ores/prototypes/energy.lua
+++ b/5dim_ores/prototypes/energy.lua
@@ -1,95 +1,89 @@
-data.raw.recipe["5d-electric-pole-6"].ingredients = {
+data.raw.recipe["5d-big-electric-pole-06"].ingredients = {
     {"advanced-circuit", 20},
     {"processing-unit", 1},
     {"steel-plate", 50},
     {"iron-plate", 100},
     {"5d-gold-wire", 5}
 }
-data.raw.recipe["5d-electric-pole-5"].ingredients = {
+data.raw.recipe["5d-big-electric-pole-05"].ingredients = {
     {"electronic-circuit", 2},
     {"steel-plate", 4},
     {"aluminium-plate", 4},
     {"copper-plate", 4}
 }
-data.raw.recipe["5d-electric-pole-4"].ingredients = {
+data.raw.recipe["5d-big-electric-pole-04"].ingredients = {
     {"steel-plate", 4},
     {"iron-plate", 4},
     {"copper-plate", 4}
 }
-data.raw.recipe["5d-offshore-pump-2"].ingredients = {
+data.raw.recipe["5d-offshore-pump-02"].ingredients = {
     {"offshore-pump", 1},
     {"aluminium-plate", 10},
     {"zinc-plate", 7},
     {"pipe", 3}
 }
-data.raw.recipe["5d-offshore-pump"].ingredients = {
-    {"offshore-pump", 1},
-    {"lead-plate", 5},
-    {"steel-plate", 5},
-    {"pipe", 3}
-}
-data.raw.recipe["5d-lamp"].ingredients = {
+data.raw.recipe["5d-lamp-02"].ingredients = {
     {"small-lamp", 1},
     {"electronic-circuit", 5},
     {"iron-plate", 5},
     {"steel-plate", 2}
 }
-data.raw.recipe["5d-boiler-2"].ingredients = {
-    {"5d-boiler", 1},
+data.raw.recipe["5d-boiler-03"].ingredients = {
+    {"5d-boiler-02", 1},
     {"zinc-plate", 5},
     {"pipe", 3}
 }
-data.raw.recipe["5d-boiler"].ingredients = {
+data.raw.recipe["5d-boiler-02"].ingredients = {
     {"boiler", 1},
     {"steel-furnace", 1},
     {"lead-plate", 2},
     {"pipe", 3}
 }
-data.raw.recipe["5d-basic-accumulator-3"].ingredients = {
-    {"5d-basic-accumulator-2", 1},
+data.raw.recipe["5d-accumulator-03"].ingredients = {
+    {"5d-accumulator-02", 1},
     {"lead-plate", 5},
     {"5d-aluminium-wire", 3},
     {"battery", 5}
 }
-data.raw.recipe["5d-basic-accumulator-2"].ingredients = {
+data.raw.recipe["5d-accumulator-02"].ingredients = {
     {"accumulator", 1},
     {"lead-plate", 10},
     {"iron-plate", 4},
     {"battery", 5}
 }
-data.raw.recipe["5d-steam-engine-3"].ingredients = {
-    {"5d-steam-engine-2", 1},
+data.raw.recipe["5d-steam-engine-03"].ingredients = {
+    {"5d-steam-engine-02", 1},
     {"5d-gold-wire", 5},
     {"5d-aluminium-gear-wheel", 2},
     {"pipe", 12},
     {"zinc-plate", 6}
 }
-data.raw.recipe["5d-steam-engine-2"].ingredients = {
+data.raw.recipe["5d-steam-engine-02"].ingredients = {
     {"steam-engine", 1},
     {"electronic-circuit", 8},
     {"pipe", 8},
     {"tin-plate", 15},
     {"lead-plate", 10}
 }
-data.raw.recipe["5d-solar-panel-3"].ingredients = {
-    {"5d-solar-panel-2", 1},
+data.raw.recipe["5d-solar-panel-03"].ingredients = {
+    {"5d-solar-panel-02", 1},
     {"steel-plate", 5},
     {"5d-gold-wire", 7},
     {"aluminium-plate", 5}
 }
-data.raw.recipe["5d-solar-panel-2"].ingredients = {
+data.raw.recipe["5d-solar-panel-02"].ingredients = {
     {"solar-panel", 1},
     {"tin-plate", 10},
     {"electronic-circuit", 7},
     {"lead-plate", 5}
 }
-data.raw.recipe["5d-small-pump-2"].ingredients = {
-    {"5d-small-pump", 1},
+data.raw.recipe["5d-pump-03"].ingredients = {
+    {"5d-pump-02", 1},
     {"electric-engine-unit", 3},
     {"lead-plate", 10},
     {"pipe", 3}
 }
-data.raw.recipe["5d-small-pump"].ingredients = {
+data.raw.recipe["5d-pump-02"].ingredients = {
     {"pump", 1},
     {"electric-engine-unit", 2},
     {"tin-plate", 10},

--- a/5dim_ores/prototypes/logistic.lua
+++ b/5dim_ores/prototypes/logistic.lua
@@ -1,45 +1,29 @@
-data.raw.recipe["5d-repair-pack-2"].ingredients = {
-    {"electronic-circuit", 2},
-    {"iron-gear-wheel", 1}
-}
-data.raw.recipe["5d-passive"].ingredients = {
-    {"logistic-chest-passive-provider", 1},
-    {"advanced-circuit", 1}
-}
-data.raw.recipe["5d-storage"].ingredients = {
-    {"logistic-chest-storage", 1},
-    {"advanced-circuit", 1}
-}
-data.raw.recipe["5d-logistic-robot-2"].ingredients = {
+data.raw.recipe["5d-logistic-robot-02"].ingredients = {
     {"logistic-robot", 1},
     {"advanced-circuit", 2}
 }
-data.raw.recipe["5d-construction-robot-2"].ingredients = {
+data.raw.recipe["5d-construction-robot-02"].ingredients = {
     {"construction-robot", 1},
     {"electronic-circuit", 2}
 }
-data.raw.recipe["5d-roboport-2"].ingredients = {
+data.raw.recipe["5d-roboport-02"].ingredients = {
     {"roboport", 1},
     {"zinc-plate", 15},
     {"processing-unit", 20}
 }
-data.raw.recipe["5d-requester"].ingredients = {
-    {"logistic-chest-requester", 1},
-    {"advanced-circuit", 1}
-}
-data.raw.recipe["5d-logistic-robot-3"].ingredients = {
-    {"5d-logistic-robot-2", 1},
+data.raw.recipe["5d-logistic-robot-03"].ingredients = {
+    {"5d-logistic-robot-02", 1},
     {"advanced-circuit", 2}
 }
-data.raw.recipe["5d-construction-robot-3"].ingredients = {
-    {"5d-construction-robot-2", 1},
+data.raw.recipe["5d-construction-robot-03"].ingredients = {
+    {"5d-construction-robot-02", 1},
     {"electronic-circuit", 2}
 }
-data.raw.recipe["5d-logistic-robot-4"].ingredients = {
-    {"5d-logistic-robot-3", 1},
+data.raw.recipe["5d-logistic-robot-04"].ingredients = {
+    {"5d-logistic-robot-03", 1},
     {"advanced-circuit", 2}
 }
-data.raw.recipe["5d-construction-robot-4"].ingredients = {
-    {"5d-construction-robot-3", 1},
+data.raw.recipe["5d-construction-robot-04"].ingredients = {
+    {"5d-construction-robot-03", 1},
     {"electronic-circuit", 2}
 }

--- a/5dim_ores/prototypes/mining.lua
+++ b/5dim_ores/prototypes/mining.lua
@@ -1,61 +1,29 @@
-data.raw.recipe["5d-mining-drill-speed-3"].ingredients = {
-    {"5d-mining-drill-speed-2", 1},
+data.raw.recipe["5d-electric-mining-drill-04"].ingredients = {
+    {"5d-electric-mining-drill-03", 1},
     {"zinc-plate", 10},
     {"5d-gold-circuit", 5}
 }
-data.raw.recipe["5d-mining-drill-speed-2"].ingredients = {
-    {"5d-mining-drill-speed-1", 1},
+data.raw.recipe["5d-electric-mining-drill-03"].ingredients = {
+    {"5d-electric-mining-drill-02", 1},
     {"5d-zinc-gear-wheel", 5},
     {"advanced-circuit", 5}
 }
-data.raw.recipe["5d-mining-drill-speed-1"].ingredients = {
+data.raw.recipe["5d-electric-mining-drill-02"].ingredients = {
     {"electric-mining-drill", 1},
     {"lead-plate", 10},
     {"5d-tin-gear-wheel", 5},
     {"electronic-circuit", 2}
 }
-data.raw.recipe["5d-mining-drill-range-3"].ingredients = {
-    {"5d-mining-drill-speed-2", 1},
-    {"zinc-plate", 10},
-    {"5d-gold-circuit", 5}
+data.raw.recipe["5d-pumpjack-03"].ingredients = {
+	{"5d-tin-gear-wheel", 20},
+	{"lead-plate", 20},
+	{"5d-pumpjack-02", 1},
+	{"pipe", 25}
 }
-data.raw.recipe["5d-mining-drill-range-2"].ingredients = {
-    {"5d-mining-drill-speed-1", 1},
-    {"5d-zinc-gear-wheel", 5},
-    {"advanced-circuit", 5}
+data.raw.recipe["5d-pumpjack-02"].ingredients = {
+	{"tin-plate", 35},
+	{"pumpjack", 1},
+	{"5d-tin-gear-wheel", 15},
+	{"electronic-circuit", 10},
+	{"pipe", 5}
 }
-data.raw.recipe["5d-mining-drill-range-1"].ingredients = {
-    {"electric-mining-drill", 1},
-    {"lead-plate", 10},
-    {"5d-tin-gear-wheel", 5},
-    {"electronic-circuit", 2}
-}
-if transport == true then
-    data.raw.recipe["5d-pumpjack-3"].ingredients = {
-        {"5d-tin-gear-wheel", 20},
-        {"lead-plate", 20},
-        {"5d-pumpjack-2", 1},
-        {"5d-pipe-mk3", 25}
-    }
-    data.raw.recipe["5d-pumpjack-2"].ingredients = {
-        {"tin-plate", 35},
-        {"pumpjack", 1},
-        {"5d-tin-gear-wheel", 15},
-        {"electronic-circuit", 10},
-        {"5d-pipe-mk2", 5}
-    }
-else
-    data.raw.recipe["5d-pumpjack-3"].ingredients = {
-        {"5d-tin-gear-wheel", 20},
-        {"lead-plate", 20},
-        {"5d-pumpjack-2", 1},
-        {"pipe", 25}
-    }
-    data.raw.recipe["5d-pumpjack-2"].ingredients = {
-        {"tin-plate", 35},
-        {"pumpjack", 1},
-        {"5d-tin-gear-wheel", 15},
-        {"electronic-circuit", 10},
-        {"pipe", 5}
-    }
-end

--- a/5dim_ores/prototypes/resources.lua
+++ b/5dim_ores/prototypes/resources.lua
@@ -1,29 +1,24 @@
-data.raw.recipe["5d-electric-furnace"].ingredients = {
+data.raw.recipe["5d-electric-furnace-02"].ingredients = {
     {"electric-furnace", 1},
     {"tin-plate", 20},
     {"5d-zinc-gear-wheel", 5},
     {"advanced-circuit", 10}
 }
 data.raw.recipe["5d-industrial-furnace"].ingredients = {
-    {"5d-electric-furnace", 2},
+    {"5d-electric-furnace-10", 2},
     {"tin-plate", 20},
     {"5d-zinc-gear-wheel", 5},
     {"advanced-circuit", 10}
 }
-data.raw.recipe["5d-furnace"].ingredients = {
-    {"steel-furnace", 1},
-    {"5d-zinc-gear-wheel", 5},
-    {"stone-brick", 10}
-}
-data.raw.recipe["5d-masher-2"].ingredients = {
+data.raw.recipe["5d-masher-02"].ingredients = {
     {"steel-plate", 3},
     {"zinc-plate", 7},
     {"tin-plate", 15},
     {"stone-brick", 20},
-    {"5d-masher", 1},
+    {"5d-masher-01", 1},
     {"advanced-circuit", 10}
 }
-data.raw.recipe["5d-masher"].ingredients = {
+data.raw.recipe["5d-masher-01"].ingredients = {
     {"iron-plate", 20},
     {"zinc-plate", 5},
     {"tin-plate", 15},
@@ -36,7 +31,7 @@ data:extend(
         {
             type = "item",
             name = "5d-tin-dust",
-            icon = "__5dim_resources__/graphics/icon/tindust-ore.png",
+            icon = "__5dim_resources__/graphics/icon/resources/5d-tin-dust.png",
             icon_size = 32,
             subgroup = "plates-dust",
             order = "c",
@@ -46,7 +41,7 @@ data:extend(
         {
             type = "item",
             name = "5d-gold-dust",
-            icon = "__5dim_resources__/graphics/icon/golddust-ore.png",
+            icon = "__5dim_resources__/graphics/icon/resources/5d-gold-dust.png",
             icon_size = 32,
             subgroup = "plates-dust",
             order = "g",
@@ -56,7 +51,7 @@ data:extend(
         {
             type = "item",
             name = "5d-lead-dust",
-            icon = "__5dim_resources__/graphics/icon/leaddust-ore.png",
+            icon = "__5dim_resources__/graphics/icon/resources/5d-lead-dust.png",
             icon_size = 32,
             subgroup = "plates-dust",
             order = "d",
@@ -66,7 +61,7 @@ data:extend(
         {
             type = "item",
             name = "5d-zinc-dust",
-            icon = "__5dim_resources__/graphics/icon/zincdust-ore.png",
+            icon = "__5dim_resources__/graphics/icon/resources/5d-zinc-dust.png",
             icon_size = 32,
             subgroup = "plates-dust",
             order = "e",
@@ -76,7 +71,7 @@ data:extend(
         {
             type = "item",
             name = "5d-aluminium-dust",
-            icon = "__5dim_resources__/graphics/icon/bauxitedust-ore.png",
+            icon = "__5dim_resources__/graphics/icon/resources/5d-bauxite-dust.png",
             icon_size = 32,
             subgroup = "plates-dust",
             order = "f",

--- a/5dim_ores/prototypes/transport.lua
+++ b/5dim_ores/prototypes/transport.lua
@@ -1,56 +1,34 @@
-data.raw.recipe["5d-mk5-transport-belt"].ingredients = {
+data.raw.recipe["5d-transport-belt-05"].ingredients = {
     {"iron-plate", 10},
     {"steel-plate", 10},
     {"processing-unit", 2},
-    {"5d-mk4-transport-belt", 2}
+    {"5d-transport-belt-04", 2}
 }
-data.raw.recipe["5d-mk4-transport-belt"].ingredients = {
+data.raw.recipe["5d-transport-belt-04"].ingredients = {
     {"iron-plate", 10},
     {"steel-plate", 10},
     {"advanced-circuit", 2},
     {"express-transport-belt", 2}
 }
-data.raw.recipe["5d-storage-tank"].ingredients = {
-    {"storage-tank", 1},
-    {"tin-plate", 15},
-    {"lead-plate", 7},
-    {"stone", 5}
-}
-data.raw.recipe["5d-mk5-splitter"].ingredients = {
-    {"5d-mk4-splitter", 5},
+if storage == true then
+	data.raw.recipe["5d-storage-tank-02"].ingredients = {
+		{"storage-tank", 1},
+		{"tin-plate", 15},
+		{"lead-plate", 7},
+		{"stone", 5}
+	}
+end
+data.raw.recipe["5d-splitter-05"].ingredients = {
+    {"5d-splitter-04", 5},
     {"processing-unit", 5},
     {"iron-plate", 5},
     {"transport-belt", 4}
 }
-data.raw.recipe["5d-mk4-splitter"].ingredients = {
+data.raw.recipe["5d-splitter-04"].ingredients = {
     {"express-splitter", 1},
     {"advanced-circuit", 15},
     {"iron-plate", 5},
     {"express-transport-belt", 4}
-}
-data.raw.recipe["5d-pipe-to-ground-mk3-50"].ingredients = {
-    {"5d-pipe-mk3", 50},
-    {"steel-plate", 5}
-}
-data.raw.recipe["5d-pipe-to-ground-mk3-30"].ingredients = {
-    {"5d-pipe-mk3", 30},
-    {"steel-plate", 5}
-}
-data.raw.recipe["5d-pipe-to-ground-mk3"].ingredients = {
-    {"5d-pipe-mk3", 10},
-    {"steel-plate", 5}
-}
-data.raw.recipe["5d-pipe-to-ground-mk2-50"].ingredients = {
-    {"5d-pipe-mk2", 50},
-    {"copper-plate", 5}
-}
-data.raw.recipe["5d-pipe-to-ground-mk2-30"].ingredients = {
-    {"5d-pipe-mk2", 30},
-    {"copper-plate", 5}
-}
-data.raw.recipe["5d-pipe-to-ground-mk2"].ingredients = {
-    {"5d-pipe-mk2", 10},
-    {"copper-plate", 5}
 }
 data.raw.recipe["5d-pipe-to-ground-mk1-50"].ingredients = {
     {"pipe", 50},
@@ -60,69 +38,51 @@ data.raw.recipe["5d-pipe-to-ground-mk1-30"].ingredients = {
     {"pipe", 30},
     {"iron-plate", 5}
 }
--- data.raw.recipe["5d-iron-chest-mk2-3"].ingredients = {
--- 		{"iron-chest", 5},
--- 		{"iron-plate", 80},
--- 		{"lead-plate", 60},
--- 		{"steel-plate", 40},
---     };
--- data.raw.recipe["5d-iron-chest-mk2-2"].ingredients = {
--- 		{"iron-chest", 1},
--- 		{"iron-plate", 20},
---     };
--- data.raw.recipe["5d-iron-chest-mk3"].ingredients = {
--- 		{"iron-chest", 4},
--- 		{"iron-plate", 20},
---     };
--- data.raw.recipe["5d-iron-chest-mk2"].ingredients = {
--- 		{"iron-chest", 1},
--- 		{"iron-plate", 20},
---     };
-data.raw.recipe["5d-mk5-transport-belt-to-ground-50"].ingredients = {
+data.raw.recipe["5d-underground-belt-50-05"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk5-transport-belt", 50}
+    {"5d-transport-belt-05", 50}
 }
-data.raw.recipe["5d-mk5-transport-belt-to-ground-30"].ingredients = {
+data.raw.recipe["5d-underground-belt-30-05"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk5-transport-belt", 30}
+    {"5d-transport-belt-05", 30}
 }
-data.raw.recipe["5d-mk5-transport-belt-to-ground"].ingredients = {
+data.raw.recipe["5d-underground-belt-05"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk5-transport-belt", 5}
+    {"5d-transport-belt-05", 5}
 }
-data.raw.recipe["5d-mk4-transport-belt-to-ground-50"].ingredients = {
+data.raw.recipe["5d-underground-belt-50-04"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk4-transport-belt", 50}
+    {"5d-transport-belt-04", 50}
 }
-data.raw.recipe["5d-mk4-transport-belt-to-ground-30"].ingredients = {
+data.raw.recipe["5d-underground-belt-30-04"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk4-transport-belt", 30}
+    {"5d-transport-belt-04", 30}
 }
-data.raw.recipe["5d-mk4-transport-belt-to-ground"].ingredients = {
+data.raw.recipe["5d-underground-belt-04"].ingredients = {
     {"iron-plate", 10},
-    {"5d-mk4-transport-belt", 5}
+    {"5d-transport-belt-04", 5}
 }
-data.raw.recipe["5d-mk3-transport-belt-to-ground-50"].ingredients = {
+data.raw.recipe["5d-express-underground-belt-50-03"].ingredients = {
     {"iron-plate", 10},
     {"express-transport-belt", 50}
 }
-data.raw.recipe["5d-mk3-transport-belt-to-ground-30"].ingredients = {
+data.raw.recipe["5d-express-underground-belt-30-03"].ingredients = {
     {"iron-plate", 10},
     {"express-transport-belt", 30}
 }
-data.raw.recipe["5d-mk2-transport-belt-to-ground-50"].ingredients = {
+data.raw.recipe["5d-fast-underground-belt-50-02"].ingredients = {
     {"iron-plate", 10},
     {"fast-transport-belt", 50}
 }
-data.raw.recipe["5d-mk2-transport-belt-to-ground-30"].ingredients = {
+data.raw.recipe["5d-fast-underground-belt-30-02"].ingredients = {
     {"iron-plate", 10},
     {"fast-transport-belt", 30}
 }
-data.raw.recipe["5d-mk1-transport-belt-to-ground-50"].ingredients = {
+data.raw.recipe["5d-underground-belt-50-01"].ingredients = {
     {"iron-plate", 10},
     {"transport-belt", 50}
 }
-data.raw.recipe["5d-mk1-transport-belt-to-ground-30"].ingredients = {
+data.raw.recipe["5d-underground-belt-30-01"].ingredients = {
     {"iron-plate", 10},
     {"transport-belt", 30}
 }

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -11,8 +11,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -32,12 +32,13 @@
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk2", "pipe"],
+		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk3", "pipe"],
+		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
-		
+		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]t
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],
@@ -51,8 +52,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -68,13 +69,14 @@
         ["5d-mk5-splitter", "5d-splitter-05"],
         ["5d-mk5-loader", "5d-loader-05"],
 		
-		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk2", "pipe"],
+		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-mk3", "pipe"],
+		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
     ],
@@ -90,8 +92,8 @@
         ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
         ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
 		
-        ["5d-express-underground-belt-30", "5d-express-underground-belt-30-03"],
-        ["5d-express-underground-belt-50", "5d-express-underground-belt-50-03"],
+        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
         
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
         ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
@@ -106,5 +108,8 @@
         ["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
         ["5d-mk5-splitter", "5d-splitter-05"],
         ["5d-mk5-loader", "5d-loader-05"]
-    ]
+    ],
+	"technology": [
+		["", ""]
+	]
 }

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -38,7 +38,7 @@
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]t
+		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],

--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -30,15 +30,15 @@
 		
 		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
 		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-mk2-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
+		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
     ],
     "entity": [
         ["long-handed-inserter", "fast-inserter"],
@@ -70,15 +70,15 @@
         ["5d-mk5-loader", "5d-loader-05"],
 		
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
 		["5d-pipe-to-ground-mk2", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk2-30", "5d-pipe-to-ground-mk1-30"],
+		["5d-pipe-to-ground-mk2-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk3", "pipe"],
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
-		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"]
+		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
     ],
 	"recipe": [
         ["long-handed-inserter", "fast-inserter"],


### PR DESCRIPTION
Partial fix for #24, requires #26 
Adapts 5Dim ores to make use of the new naming scheme.
I've removed some items from Ores, so please check this carefully.

**5dim_ores/prototypes/energy.lua**
- I've adapted energy pole to big energy pole, assuming this was the one that was meant.
- Removed duplicate offshore pump recipe

**5dim_ores/prototypes/logistic.lua**
- Removed repair pack, could not find the new name in the new files.
- removed passive, storage and requester. Could also not find these upgraded items in the files.

**5dim_ores/prototypes/mining.lua**
- Removed all -range- miners, could not find them in the files
- Changed all -speed- miners to "standard" upgrade, following in-game upgrades.
- Removed _transport_ if statement, due to removal of mk+ pipes

**5dim_ores/prototypes/resources.lua**
- Removed furnace, could not find it.
- Adapted industrial furnace to use mk10 furnaces, to match base 5Dim.
- Edited resources to use proper files.

**5dim_ores/prototypes/transport.lua**
- Added if statement around storage tank, for if one does not have 5Dim Storage (does this work like this?)
- Removed mk+ pipes
- Removed commented code; that's for version control ;)