### PR TITLE
Adding Productivity compatibility with plates/dust

### DIFF
--- a/5dim_core/lib/module/generation-module.lua
+++ b/5dim_core/lib/module/generation-module.lua
@@ -1,43 +1,3 @@
-
-function fiveDimsHasLimitationRecipe(limitations, recipe_name)
-    local has_it = false
-    if limitations and #limitations > 0 then
-        for i, name in pairs(limitations) do
-        if name == recipe_name then
-            has_it = true
-            break
-        end
-        end
-    end
-    return has_it
-end
-
-function fiveDimsAddProductivityLimitation(module, recipe_name)
-    local has_it = false
-    local recipeExists = false
-
-    if data.raw.recipe[recipe_name] then
-        recipeExists = true
-    else
-        return
-    end
-
-    if module.limitation then
-        has_it = fiveDimsHasLimitationRecipe(module.limitation, recipe_name)
-      else
-        module.limitation = {}
-      end
-
-      if not has_it and recipeExists == true then
-
-        table.insert(module.limitation, recipe_name)
-
-        if not module.limitation_message_key then
-          module.limitation_message_key = "production-module-limitation"
-        end
-      end
-end
-
 function genModules(inputs)
     -- Copy Speed module
     local itemSpeed = ""
@@ -168,11 +128,6 @@ function genModules(inputs)
     itemProductivity.order = inputs.order
     itemProductivity.effect = inputs.effects.productivity
     itemProductivity.tier = inputs.tier
-
-    fiveDimsAddProductivityLimitation(itemProductivity, '5d-iron-plate')
-    fiveDimsAddProductivityLimitation(itemProductivity, '5d-iron-dust')
-    fiveDimsAddProductivityLimitation(itemProductivity, '5d-copper-plate')
-    fiveDimsAddProductivityLimitation(itemProductivity, '5d-copper-dust')
 
     --Recipe
     recipeProductivity.name = itemProductivity.name

--- a/5dim_core/lib/module/generation-module.lua
+++ b/5dim_core/lib/module/generation-module.lua
@@ -14,13 +14,22 @@ end
 
 function fiveDimsAddProductivityLimitation(module, recipe_name)
     local has_it = false
+    local recipeExists = false
+
+    if data.raw.recipe[recipe_name] then
+        recipeExists = true
+    else
+        return
+    end
+
     if module.limitation then
         has_it = fiveDimsHasLimitationRecipe(module.limitation, recipe_name)
       else
         module.limitation = {}
       end
 
-      if not has_it then
+      if not has_it and recipeExists == true then
+
         table.insert(module.limitation, recipe_name)
 
         if not module.limitation_message_key then

--- a/5dim_core/lib/module/generation-module.lua
+++ b/5dim_core/lib/module/generation-module.lua
@@ -1,3 +1,34 @@
+
+function fiveDimsHasLimitationRecipe(limitations, recipe_name)
+    local has_it = false
+    if limitations and #limitations > 0 then
+        for i, name in pairs(limitations) do
+        if name == recipe_name then
+            has_it = true
+            break
+        end
+        end
+    end
+    return has_it
+end
+
+function fiveDimsAddProductivityLimitation(module, recipe_name)
+    local has_it = false
+    if module.limitation then
+        has_it = fiveDimsHasLimitationRecipe(module.limitation, recipe_name)
+      else
+        module.limitation = {}
+      end
+
+      if not has_it then
+        table.insert(module.limitation, recipe_name)
+
+        if not module.limitation_message_key then
+          module.limitation_message_key = "production-module-limitation"
+        end
+      end
+end
+
 function genModules(inputs)
     -- Copy Speed module
     local itemSpeed = ""
@@ -128,6 +159,11 @@ function genModules(inputs)
     itemProductivity.order = inputs.order
     itemProductivity.effect = inputs.effects.productivity
     itemProductivity.tier = inputs.tier
+
+    fiveDimsAddProductivityLimitation(itemProductivity, '5d-iron-plate')
+    fiveDimsAddProductivityLimitation(itemProductivity, '5d-iron-dust')
+    fiveDimsAddProductivityLimitation(itemProductivity, '5d-copper-plate')
+    fiveDimsAddProductivityLimitation(itemProductivity, '5d-copper-dust')
 
     --Recipe
     recipeProductivity.name = itemProductivity.name

--- a/5dim_resources/data-final-fixes.lua
+++ b/5dim_resources/data-final-fixes.lua
@@ -1,0 +1,55 @@
+
+local function hasLimitationRecipe(limitations, recipe_name)
+    local has_it = false
+    if limitations and #limitations > 0 then
+        for i, name in pairs(limitations) do
+        if name == recipe_name then
+            has_it = true
+            break
+        end
+        end
+    end
+    return has_it
+end
+
+local function addProductivityLimitation(module, recipe_name)
+    local has_it = false
+
+    if module.limitation then
+        has_it = hasLimitationRecipe(module.limitation, recipe_name)
+      else
+        module.limitation = {}
+      end
+
+      if not has_it then
+
+        table.insert(module.limitation, recipe_name)
+
+        if not module.limitation_message_key then
+          module.limitation_message_key = "production-module-limitation"
+        end
+      end
+end
+
+local function checkModuleHasProductivity(module)
+    if module.effect then
+        for effect_name, effect in pairs(module.effect) do
+          if effect_name == "productivity" and effect.bonus > 0 then
+            return true
+          end
+        end
+      end
+      return false
+end
+
+
+if mods["5dim_resources"] then
+    for _, module in pairs(data.raw.module) do
+        if checkModuleHasProductivity(module) then
+            addProductivityLimitation(module, '5d-iron-plate')
+            addProductivityLimitation(module, '5d-iron-dust')
+            addProductivityLimitation(module, '5d-copper-plate')
+            addProductivityLimitation(module, '5d-copper-dust')
+        end
+    end
+end


### PR DESCRIPTION
Bug report:

- While you can insert productivity modules in masher/electric furnace , the bonus effect was not having the desired effect.

Changes:
- Created file 5dim_resources/data-final-fixes.lua
- Added some helper functions and logic to check when 5dim_resources is added in 5dim_resources/data-final-fixes.lua
- Added "5d-iron-plate/dust" compatibility with productivity modules
- Added "5d-copper-palate/dust" compatibility with productivity modules

Evidence before: 

![image](https://user-images.githubusercontent.com/17688159/139158239-a7d1da7a-ec52-471a-8b17-6bccfdaaa9d2.png)
 
Evidence After:

![image](https://user-images.githubusercontent.com/17688159/139158334-31e836f8-0db6-4e8d-b7c2-672f63ed45da.png)
