### PR TITLE
Fix enable/disable for swimmer bitters

### DIFF
--- a/5dim_enemies/prototypes/biter/gen-biters.lua
+++ b/5dim_enemies/prototypes/biter/gen-biters.lua
@@ -44,7 +44,7 @@ genBiter {
 }
 
 -- Climber
-if settings.startup["5d-swimmer"].value then
+if settings.startup["5d-climber"].value then
     genBiter {
         tint = biter.colors.primary.climber,
         tint2 = biter.colors.secondary.secondColor,
@@ -61,7 +61,7 @@ if settings.startup["5d-swimmer"].value then
 end
 
 -- Swimmer
-if settings.startup["5d-climber"].value then
+if settings.startup["5d-swimmer"].value then
     genBiter {
         tint = biter.colors.primary.swimmer,
         tint2 = biter.colors.secondary.secondColor,


### PR DESCRIPTION
Bug report:
- When you choose to disable swimmer enemies in the startup config, you still get swimmer bitters because the check for it in the bitter's gen was checking for climber. Swimmer spitters were fine.