### PR TITLE
Disable migration of long inserters

### DIFF
--- a/5dim_transport/migrations/5dim_transport_1.1.0.json
+++ b/5dim_transport/migrations/5dim_transport_1.1.0.json
@@ -1,34 +1,32 @@
 {
-    "item": [
-        ["long-handed-inserter", "fast-inserter"],
-        ["fast-inserter", "5d-inserter-03"],
-        ["5d-loader-09", "5d-loader-08"],
-        ["5d-loader-10", "5d-loader-08"],
-		
-        ["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
-        ["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
-		
-        ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
-        ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
-		
-        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
-        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
-        
+	"item": [
+		["fast-inserter", "5d-inserter-03"],
+		["5d-loader-09", "5d-loader-08"],
+		["5d-loader-10", "5d-loader-08"],
+
+		["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
+		["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
+
+		["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
+		["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
+
+		["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+		["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
+
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
-        ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
-        ["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
-        ["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
-        ["5d-mk4-splitter", "5d-splitter-04"],
-        ["5d-mk4-loader", "5d-loader-04"],
-		
+		["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
+		["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
+		["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
+		["5d-mk4-splitter", "5d-splitter-04"],
+		["5d-mk4-loader", "5d-loader-04"],
+
 		["5d-mk5-transport-belt", "5d-transport-belt-05"],
-        ["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
-        ["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
-        ["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
-        ["5d-mk5-splitter", "5d-splitter-05"],
-        ["5d-mk5-loader", "5d-loader-05"],
-		
-		
+		["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
+		["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
+		["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
+		["5d-mk5-splitter", "5d-splitter-05"],
+		["5d-mk5-loader", "5d-loader-05"],
+
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
@@ -39,36 +37,35 @@
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
-    ],
-    "entity": [
-        ["long-handed-inserter", "fast-inserter"],
-        ["fast-inserter", "5d-inserter-03"],
-        ["5d-loader-09", "5d-loader-08"],
-        ["5d-loader-10", "5d-loader-08"],
-		
-        ["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
-        ["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
-		
-        ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
-        ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
-		
-        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
-        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
-        
+	],
+	"entity": [
+		["fast-inserter", "5d-inserter-03"],
+		["5d-loader-09", "5d-loader-08"],
+		["5d-loader-10", "5d-loader-08"],
+
+		["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
+		["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
+
+		["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
+		["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
+
+		["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+		["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
+
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
-        ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
-        ["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
-        ["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
-        ["5d-mk4-splitter", "5d-splitter-04"],
-        ["5d-mk4-loader", "5d-loader-04"],
-		
+		["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
+		["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
+		["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
+		["5d-mk4-splitter", "5d-splitter-04"],
+		["5d-mk4-loader", "5d-loader-04"],
+
 		["5d-mk5-transport-belt", "5d-transport-belt-05"],
-        ["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
-        ["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
-        ["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
-        ["5d-mk5-splitter", "5d-splitter-05"],
-        ["5d-mk5-loader", "5d-loader-05"],
-		
+		["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
+		["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
+		["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
+		["5d-mk5-splitter", "5d-splitter-05"],
+		["5d-mk5-loader", "5d-loader-05"],
+
 		["5d-pipe-to-ground-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-50", "5d-pipe-to-ground-mk1-50"],
 		["5d-pipe-mk2", "pipe"],
@@ -79,37 +76,34 @@
 		["5d-pipe-to-ground-mk3", "pipe-to-ground"],
 		["5d-pipe-to-ground-mk3-30", "5d-pipe-to-ground-mk1-30"],
 		["5d-pipe-to-ground-mk3-50", "5d-pipe-to-ground-mk1-50"]
-    ],
+	],
 	"recipe": [
-        ["long-handed-inserter", "fast-inserter"],
-        ["fast-inserter", "5d-inserter-03"],
-        ["5d-loader-09", "5d-loader-08"],
-        ["5d-loader-10", "5d-loader-08"],
-		
-        ["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
-        ["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
-		
-        ["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
-        ["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
-		
-        ["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
-        ["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
-        
+		["fast-inserter", "5d-inserter-03"],
+		["5d-loader-09", "5d-loader-08"],
+		["5d-loader-10", "5d-loader-08"],
+
+		["5d-mk1-transport-belt-to-ground-30", "5d-underground-belt-30-01"],
+		["5d-mk1-transport-belt-to-ground-50", "5d-underground-belt-50-01"],
+
+		["5d-mk2-transport-belt-to-ground-30", "5d-fast-underground-belt-30-02"],
+		["5d-mk2-transport-belt-to-ground-50", "5d-fast-underground-belt-50-02"],
+
+		["5d-mk3-transport-belt-to-ground-30", "5d-express-underground-belt-30-03"],
+		["5d-mk3-transport-belt-to-ground-50", "5d-express-underground-belt-50-03"],
+
 		["5d-mk4-transport-belt", "5d-transport-belt-04"],
-        ["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
-        ["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
-        ["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
-        ["5d-mk4-splitter", "5d-splitter-04"],
-        ["5d-mk4-loader", "5d-loader-04"],
-		
+		["5d-mk4-transport-belt-to-ground", "5d-underground-belt-04"],
+		["5d-mk4-transport-belt-to-ground-30", "5d-underground-belt-30-04"],
+		["5d-mk4-transport-belt-to-ground-50", "5d-underground-belt-50-04"],
+		["5d-mk4-splitter", "5d-splitter-04"],
+		["5d-mk4-loader", "5d-loader-04"],
+
 		["5d-mk5-transport-belt", "5d-transport-belt-05"],
-        ["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
-        ["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
-        ["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
-        ["5d-mk5-splitter", "5d-splitter-05"],
-        ["5d-mk5-loader", "5d-loader-05"]
-    ],
-	"technology": [
-		["", ""]
-	]
+		["5d-mk5-transport-belt-to-ground", "5d-underground-belt-05"],
+		["5d-mk5-transport-belt-to-ground-30", "5d-underground-belt-30-05"],
+		["5d-mk5-transport-belt-to-ground-50", "5d-underground-belt-50-05"],
+		["5d-mk5-splitter", "5d-splitter-05"],
+		["5d-mk5-loader", "5d-loader-05"]
+	],
+	"technology": [["", ""]]
 }


### PR DESCRIPTION
## What
Removed the migration of long inserters into fast inserters found in this migration JSON file.

## Why
Because the migration affects all blueprints and changes all items within the blueprints into their replacements, it messes with blueprints too much because there are no upgraded versions of the long inserters specifically, with the default longer pickup and insert positions.

If this migration is left in, it will "break" a lot of blueprints, as there is no swap-in replacement for the long inserter, due to the reasons mentioned above.

### Break?
Blueprints will no longer function as expected, as the pickup and insert positions of the mk3 inserter (the long inserter's replacement) are different from the long inserter.

## Possible future solutions
- Add a startup setting to enable the replacement of the long inserters for those who want it.
- Create upgraded tiers specifically for the long inserters.